### PR TITLE
Disable check detection using pkg_check_modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
 find_package(PkgConfig QUIET)
 
-if(PKG_CONFIG_FOUND)
-    pkg_check_modules(CHECK QUIET check>=0.10)
-endif()
-
 if(NOT CHECK_FOUND)
     find_package(Check QUIET 0.10)
 endif()

--- a/deps/ccommon/CMakeLists.txt
+++ b/deps/ccommon/CMakeLists.txt
@@ -142,10 +142,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
 find_package(PkgConfig QUIET)
 
-if(PKG_CONFIG_FOUND)
-    pkg_check_modules(CHECK QUIET check>=0.10)
-endif()
-
 if(NOT CHECK_FOUND)
     find_package(Check QUIET 0.10)
 endif()


### PR DESCRIPTION
- pkg_check_modules results in:
CMake Error at deps/ccommon/test/time/wheel/CMakeLists.txt:7
(target_link_libraries):
- find_package command works fine for check package

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/1)
<!-- Reviewable:end -->
