### PR TITLE
Recreate slabs after graceful shutdown

### DIFF
--- a/src/storage/slab/item.h
+++ b/src/storage/slab/item.h
@@ -210,5 +210,8 @@ void item_update(struct item *it, const struct bstring *val);
 /* Remove item from cache */
 bool item_delete(const struct bstring *key);
 
+/* Relink item */
+void item_relink(struct item *it);
+
 /* flush the cache */
 void item_flush(void);

--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -26,6 +26,7 @@ struct slab_heapinfo {
 };
 
 static struct datapool *pool_slab;              /* data pool mapping for the slabs */
+static int pool_slab_state;                     /* data pool state */
 perslab_metrics_st perslab[SLABCLASS_MAX_ID];
 uint8_t profile_last_id; /* last id in slab profile */
 
@@ -128,6 +129,90 @@ slab_id(size_t size)
 }
 
 /*
+ * Put an item back into the slab by inserting into the item free Q.
+ */
+static void
+_slab_put_item_into_freeq(struct item *it, uint8_t id)
+{
+    struct slabclass *p = &slabclass[id];
+
+    ASSERT(id >= SLABCLASS_MIN_ID && id <= profile_last_id);
+    ASSERT(item_to_slab(it)->id == id);
+    ASSERT(!(it->is_linked));
+    ASSERT(it->offset != 0);
+
+    log_verb("put free q it %p at offset %"PRIu32" with id %"PRIu8, it,
+            it->offset, it->id);
+
+    it->in_freeq = 1;
+
+    p->nfree_itemq++;
+    SLIST_INSERT_HEAD(&p->free_itemq, it, i_sle);
+
+    PERSLAB_INCR(id, item_free);
+}
+
+/*
+ * Recreate items
+ */
+static void
+_slab_recreate_items(struct slab *slab)
+{
+    struct slabclass *p;
+    struct item *it;
+    uint32_t i;
+
+    p = &slabclass[slab->id];
+
+    for (i = 0; i < p->nitem; i++) {
+        it = _slab_to_item(slab, i, p->size);
+        if (it->is_linked) {
+            INCR(slab_metrics, item_curr);
+            INCR(slab_metrics, item_alloc);
+            PERSLAB_INCR(slab->id, item_curr);
+            item_relink(it);
+        } else if (it->in_freeq) {
+            _slab_put_item_into_freeq(it,slab->id);
+        }
+    }
+}
+
+static void
+_slab_table_update(struct slab *slab)
+{
+    ASSERT(heapinfo.nslab < heapinfo.max_nslab);
+
+    heapinfo.slab_table[heapinfo.nslab] = slab;
+    heapinfo.nslab++;
+
+    log_verb("new slab %p allocated at pos %u", slab,
+              heapinfo.nslab - 1);
+}
+
+/*
+ * Recreate slabs structure when persistent memory features are enabled (USE_PMEM)
+ */
+static void
+_slab_recovery(void)
+{
+    uint32_t i;
+    uint8_t * heap_start = datapool_addr(pool_slab);
+    /* TODO: recreate heapinfo.slab_lruq */
+    for(i = 0; i < heapinfo.max_nslab; i++) {
+        struct slab *slab = (struct slab *) heap_start;
+        if (slab->initialized) {
+            INCR(slab_metrics, slab_req);
+            _slab_table_update(slab);
+            INCR(slab_metrics, slab_curr);
+            PERSLAB_INCR(slab->id, slab_curr);
+            INCR_N(slab_metrics, slab_memory, slab_size);
+            _slab_recreate_items(slab);
+        }
+        heap_start += slab_size;
+    }
+}
+
+/*
  * Initialize all slabclasses.
  *
  * Every slabclass is a collection of slabs of fixed size specified by
@@ -171,6 +256,10 @@ _slab_slabclass_setup(void)
         p->next_item_in_slab = NULL;
     }
 
+    if (pool_slab_state == 0) {
+        _slab_recovery();
+    }
+
     return CC_OK;
 }
 
@@ -195,7 +284,7 @@ _slab_heapinfo_setup(void)
 
     heapinfo.base = NULL;
     if (prealloc) {
-        pool_slab = datapool_open(slab_datapool, heapinfo.max_nslab * slab_size, NULL);
+        pool_slab = datapool_open(slab_datapool, heapinfo.max_nslab * slab_size, &pool_slab_state);
         if (pool_slab == NULL) {
             log_crit("Could not create pool_slab");
             exit(EX_CONFIG);
@@ -479,7 +568,8 @@ _slab_hdr_init(struct slab *slab, uint8_t id)
     slab->magic = SLAB_MAGIC;
 #endif
     slab->id = id;
-    slab->padding = 0;
+    slab->initialized = 1;
+    slab->unused = 0;
     slab->refcount = 0;
 }
 
@@ -502,18 +592,6 @@ _slab_heap_create(void)
     }
 
     return slab;
-}
-
-static void
-_slab_table_update(struct slab *slab)
-{
-    ASSERT(heapinfo.nslab < heapinfo.max_nslab);
-
-    heapinfo.slab_table[heapinfo.nslab] = slab;
-    heapinfo.nslab++;
-
-    log_verb("new slab %p allocated at pos %u", slab,
-              heapinfo.nslab - 1);
 }
 
 static struct slab *
@@ -847,35 +925,11 @@ slab_get_item(uint8_t id)
 }
 
 /*
- * Put an item back into the slab by inserting into the item free Q.
- */
-static void
-_slab_put_item_into_freeq(struct item *it, uint8_t id)
-{
-    struct slabclass *p = &slabclass[id];
-
-    ASSERT(id >= SLABCLASS_MIN_ID && id <= profile_last_id);
-    ASSERT(item_to_slab(it)->id == id);
-    ASSERT(!(it->is_linked));
-    ASSERT(!(it->in_freeq));
-    ASSERT(it->offset != 0);
-
-    log_verb("put free q it %p at offset %"PRIu32" with id %"PRIu8, it,
-            it->offset, it->id);
-
-    it->in_freeq = 1;
-
-    p->nfree_itemq++;
-    SLIST_INSERT_HEAD(&p->free_itemq, it, i_sle);
-
-    PERSLAB_INCR(id, item_free);
-}
-
-/*
  * Put an item back into the slab
  */
 void
 slab_put_item(struct item *it, uint8_t id)
 {
+     ASSERT(!(it->in_freeq));
     _slab_put_item_into_freeq(it, id);
 }

--- a/src/storage/slab/slab.h
+++ b/src/storage/slab/slab.h
@@ -129,7 +129,8 @@ struct slab {
     TAILQ_ENTRY(slab) s_tqe;        /* link in slab lruq */
 
     uint8_t           id;           /* slabclass id */
-    uint32_t          padding:24;   /* unused */
+    uint8_t           initialized;  /* flag is slab initialized*/
+    uint16_t          unused;       /* unused, must be 0 */
     uint32_t          refcount;     /* # items that can't be evicted */
     uint8_t           data[1];      /* opaque data */
 };

--- a/test/storage/slab_pmem/check_slab_pmem.c
+++ b/test/storage/slab_pmem/check_slab_pmem.c
@@ -129,11 +129,9 @@ START_TEST(test_insert_basic)
 
     test_assert_insert_basic_entry_exists(key);
 
+    test_reset(0);
 
-/* TODO: uncomment after support of recreating the slab */
-//    test_reset(0);
-
-//    test_assert_insert_basic_entry_exists(key);
+    test_assert_insert_basic_entry_exists(key);
 
 #undef MLEN
 #undef KEY
@@ -170,10 +168,9 @@ START_TEST(test_insert_large)
 
     test_assert_insert_large_entry_exists(key);
 
-/* TODO: uncomment after support of recreating the slab */
-//    test_reset(0);
+    test_reset(0);
 
-//    test_assert_insert_large_entry_exists(key);
+    test_assert_insert_large_entry_exists(key);
 
 #undef VLEN
 #undef KEY
@@ -210,10 +207,9 @@ START_TEST(test_reserve_backfill_link)
     item_insert(it, &key);
     test_assert_reserve_backfill_link_exists(it);
 
-/* TODO: uncomment after support of recreating the slab */
-//    test_reset(0);
+    test_reset(0);
 
-//    test_assert_reserve_backfill_link_exists(it);
+    test_assert_reserve_backfill_link_exists(it);
 
 #undef VLEN
 #undef KEY
@@ -249,8 +245,7 @@ START_TEST(test_append_basic)
     status = item_annex(it, &key, &append, true);
     ck_assert_msg(status == ITEM_OK, "item_append not OK - return status %d", status);
 
-/* TODO: uncomment after support of recreating the slab */
-//    test_reset(0);
+    test_reset(0);
 
     it = item_get(&key);
     ck_assert_msg(it != NULL, "item_get could not find key %.*s", key.len, key.data);
@@ -295,8 +290,7 @@ START_TEST(test_prepend_basic)
     status = item_annex(it, &key, &prepend, false);
     ck_assert_msg(status == ITEM_OK, "item_prepend not OK - return status %d", status);
 
-/* TODO: uncomment after support of recreating the slab */
-//    test_reset(0);
+    test_reset(0);
 
     it = item_get(&key);
     ck_assert_msg(it != NULL, "item_get could not find key %.*s", key.len, key.data);


### PR DESCRIPTION
- USE_PMEM configuration allows to restore hashtable storage

-Continue of PR #3
-Recreate slab_lruq will be done in next PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/4)
<!-- Reviewable:end -->
