### PR TITLE
Fix cleaning after partial request and code cleanup

### DIFF
--- a/src/datapool/datapool_pmem.c
+++ b/src/datapool/datapool_pmem.c
@@ -65,7 +65,7 @@ datapool_sync(struct datapool *pool)
 static bool
 datapool_valid(struct datapool *pool)
 {
-    if (memcmp(pool->hdr->signature,
+    if (cc_memcmp(pool->hdr->signature,
           DATAPOOL_SIGNATURE, DATAPOOL_SIGNATURE_LEN) != 0) {
         log_info("no signature found in datapool");
         return false;
@@ -107,7 +107,7 @@ datapool_initialize(struct datapool *pool)
     log_info("initializing fresh datapool");
 
     /* 1. clear the header from any leftovers */
-    memset(pool->hdr, 0, DATAPOOL_HEADER_LEN);
+    cc_memset(pool->hdr, 0, DATAPOOL_HEADER_LEN);
     datapool_sync_hdr(pool);
 
     /* 2. fill in the data */
@@ -117,7 +117,7 @@ datapool_initialize(struct datapool *pool)
     datapool_sync_hdr(pool);
 
     /* 3. set the signature */
-    memcpy(pool->hdr->signature, DATAPOOL_SIGNATURE, DATAPOOL_SIGNATURE_LEN);
+    cc_memcpy(pool->hdr->signature, DATAPOOL_SIGNATURE, DATAPOOL_SIGNATURE_LEN);
     datapool_sync_hdr(pool);
 }
 

--- a/src/server/slimcache/data/process.c
+++ b/src/server/slimcache/data/process.c
@@ -448,6 +448,12 @@ _cleanup(struct request **req, struct response **rsp)
     response_return_all(rsp);
 }
 
+static inline void
+_cleanup_req(struct request **req)
+{
+    request_return(req);
+}
+
 int
 slimcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
 {
@@ -480,6 +486,7 @@ slimcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
         if (status == PARSE_EUNFIN || req->partial) { /* ignore partial */
             (*rbuf)->rpos = old_rpos;
             buf_lshift(*rbuf);
+            _cleanup_req(&req);
             return 0;
         }
         if (status != PARSE_OK) {

--- a/src/storage/slab/slab.h
+++ b/src/storage/slab/slab.h
@@ -22,7 +22,6 @@
 #define SLAB_EVICT_OPT  EVICT_RS
 #define SLAB_USE_FREEQ  true
 #define SLAB_PROFILE    NULL
-#define SLAB_HASH       16
 #define SLAB_USE_CAS    true
 #define ITEM_SIZE_MIN   44      /* 40 bytes item overhead */
 #define ITEM_SIZE_MAX   (SLAB_SIZE - SLAB_HDR_SIZE)


### PR DESCRIPTION
- Use wrapper around common routines for datapool
- Remove unused SLAB_HASH macro
- Fix cleaning after partial request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/5)
<!-- Reviewable:end -->
