### PR TITLE
Prefault option in storage engine

### DIFF
--- a/src/datapool/datapool.h
+++ b/src/datapool/datapool.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <stddef.h>
-
+#include <stdbool.h>
 struct datapool;
 
 struct datapool *datapool_open(const char *path, size_t size,
-	int *fresh);
+    int *fresh, bool prefault);
 void datapool_close(struct datapool *pool);
 
 void *datapool_addr(struct datapool *pool);

--- a/src/datapool/datapool_shm.c
+++ b/src/datapool/datapool_shm.c
@@ -8,7 +8,7 @@
 #include <cc_mm.h>
 
 struct datapool *
-datapool_open(const char *path, size_t size, int *fresh)
+datapool_open(const char *path, size_t size, int *fresh, bool prefault)
 {
     if (path != NULL) {
         log_warn("attempted to open a file-based data pool without"

--- a/src/storage/cuckoo/cuckoo.c
+++ b/src/storage/cuckoo/cuckoo.c
@@ -289,7 +289,7 @@ cuckoo_setup(cuckoo_options_st *options, cuckoo_metrics_st *metrics)
 
     hash_size = item_size * max_nitem;
     pool = datapool_open(option_str(&options->cuckoo_datapool),
-        hash_size, NULL);
+        hash_size, NULL, option_bool(&options->cuckoo_datapool_prefault));
     if (pool == NULL) {
         log_crit("cuckoo data store allocation failed");
         exit(EX_CONFIG);

--- a/src/storage/cuckoo/cuckoo.h
+++ b/src/storage/cuckoo/cuckoo.h
@@ -18,16 +18,18 @@
 #define CUCKOO_POLICY CUCKOO_POLICY_RANDOM
 #define CUCKOO_MAX_TTL (30 * 24 * 60 * 60) /* 30 days */
 #define CUCKOO_DATAPOOL NULL
+#define CUCKOO_PREFAULT false
 
-/*          name                type                default             description */
-#define CUCKOO_OPTION(ACTION)                                                                    \
-    ACTION( cuckoo_displace,    OPTION_TYPE_UINT,   CUCKOO_DISPLACE,    "# displaces allowed"   )\
-    ACTION( cuckoo_item_cas,    OPTION_TYPE_BOOL,   CUCKOO_ITEM_CAS,    "support cas in items"  )\
-    ACTION( cuckoo_item_size,   OPTION_TYPE_UINT,   CUCKOO_ITEM_SIZE,   "item size (inclusive)" )\
-    ACTION( cuckoo_nitem,       OPTION_TYPE_UINT,   CUCKOO_NITEM,       "# items allocated"     )\
-    ACTION( cuckoo_policy,      OPTION_TYPE_UINT,   CUCKOO_POLICY,      "evict policy"          )\
-    ACTION( cuckoo_max_ttl,     OPTION_TYPE_UINT,   CUCKOO_MAX_TTL,     "max ttl in seconds"    )\
-    ACTION( cuckoo_datapool,    OPTION_TYPE_STR,    CUCKOO_DATAPOOL,    "path to data pool"     )
+/*          name                      type                default             description */
+#define CUCKOO_OPTION(ACTION)                                                                          \
+    ACTION( cuckoo_displace,          OPTION_TYPE_UINT,   CUCKOO_DISPLACE,    "# displaces allowed"   )\
+    ACTION( cuckoo_item_cas,          OPTION_TYPE_BOOL,   CUCKOO_ITEM_CAS,    "support cas in items"  )\
+    ACTION( cuckoo_item_size,         OPTION_TYPE_UINT,   CUCKOO_ITEM_SIZE,   "item size (inclusive)" )\
+    ACTION( cuckoo_nitem,             OPTION_TYPE_UINT,   CUCKOO_NITEM,       "# items allocated"     )\
+    ACTION( cuckoo_policy,            OPTION_TYPE_UINT,   CUCKOO_POLICY,      "evict policy"          )\
+    ACTION( cuckoo_max_ttl,           OPTION_TYPE_UINT,   CUCKOO_MAX_TTL,     "max ttl in seconds"    )\
+    ACTION( cuckoo_datapool,          OPTION_TYPE_STR,    CUCKOO_DATAPOOL,    "path to data pool"     )\
+    ACTION( cuckoo_datapool_prefault, OPTION_TYPE_BOOL,   CUCKOO_PREFAULT,    "prefault data pool"    )
 
 typedef struct {
     CUCKOO_OPTION(OPTION_DECLARE)

--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -48,7 +48,8 @@ static size_t item_min = ITEM_SIZE_MIN; /* min item size */
 static size_t item_max = ITEM_SIZE_MAX; /* max item size */
 static double item_growth = ITEM_FACTOR;/* item size growth factor */
 static uint32_t hash_power = HASH_POWER;/* power (of 2) entries for hashtable */
-static char *slab_datapool = SLAB_DATAPOOL;   /* slab_datapool path */
+static char *slab_datapool = SLAB_DATAPOOL;   /* slab datapool path */
+static bool prefault = SLAB_PREFAULT;         /* slab datapool prefault option */
 
 bool use_cas = SLAB_USE_CAS;
 struct hash_table *hash_table = NULL;
@@ -313,7 +314,7 @@ _slab_heapinfo_setup(void)
 
     heapinfo.base = NULL;
     if (prealloc) {
-        pool_slab = datapool_open(slab_datapool, heapinfo.max_nslab * slab_size, &pool_slab_state);
+        pool_slab = datapool_open(slab_datapool, heapinfo.max_nslab * slab_size, &pool_slab_state, prefault);
         if (pool_slab == NULL) {
             log_crit("Could not create pool_slab");
             exit(EX_CONFIG);
@@ -563,6 +564,7 @@ slab_setup(slab_options_st *options, slab_metrics_st *metrics)
         use_cas = option_bool(&options->slab_use_cas);
         hash_power = option_uint(&options->slab_hash_power);
         slab_datapool = option_str(&options->slab_datapool);
+        prefault = option_bool(&options->slab_datapool_prefault);
     }
 
     hash_table = hashtable_create(hash_power);

--- a/src/storage/slab/slab.h
+++ b/src/storage/slab/slab.h
@@ -29,6 +29,7 @@
 #define ITEM_MAX_TTL    (30 * 24 * 60 * 60) /* 30 days */
 #define HASH_POWER      16
 #define SLAB_DATAPOOL   NULL
+#define SLAB_PREFAULT   false
 
 /* Eviction options */
 #define EVICT_NONE    0 /* throw OOM, no eviction */
@@ -38,21 +39,23 @@
 
 /* The defaults here are placeholder values for now */
 /* TODO: consider moving item options to item.[h|c] */
-/*          name                type                default         description */
-#define SLAB_OPTION(ACTION)                                                                          \
-    ACTION( slab_size,          OPTION_TYPE_UINT,   SLAB_SIZE,      "Slab size"                     )\
-    ACTION( slab_mem,           OPTION_TYPE_UINT,   SLAB_MEM,       "Max memory by slabs (byte)"    )\
-    ACTION( slab_prealloc,      OPTION_TYPE_BOOL,   SLAB_PREALLOC,  "Pre-allocate slabs at setup"   )\
-    ACTION( slab_evict_opt,     OPTION_TYPE_UINT,   SLAB_EVICT_OPT, "Eviction strategy"             )\
-    ACTION( slab_use_freeq,     OPTION_TYPE_BOOL,   SLAB_USE_FREEQ, "Use items in free queue?"      )\
-    ACTION( slab_profile,       OPTION_TYPE_STR,    SLAB_PROFILE,   "Specify entire slab profile"   )\
-    ACTION( slab_item_min,      OPTION_TYPE_UINT,   ITEM_SIZE_MIN,  "Minimum item size"             )\
-    ACTION( slab_item_max,      OPTION_TYPE_UINT,   ITEM_SIZE_MAX,  "Maximum item size"             )\
-    ACTION( slab_item_growth,   OPTION_TYPE_FPN,    ITEM_FACTOR,    "Slab class growth factor"      )\
-    ACTION( slab_item_max_ttl,  OPTION_TYPE_UINT,   ITEM_MAX_TTL,   "Max ttl in seconds"            )\
-    ACTION( slab_use_cas,       OPTION_TYPE_BOOL,   SLAB_USE_CAS,   "Store CAS value in item"       )\
-    ACTION( slab_hash_power,    OPTION_TYPE_UINT,   HASH_POWER,     "Power for lookup hash table"   )\
-    ACTION( slab_datapool,      OPTION_TYPE_STR,    SLAB_DATAPOOL,  "Path to data pool"             )
+/*          name                    type                default         description */
+#define SLAB_OPTION(ACTION)                                                                              \
+    ACTION( slab_size,              OPTION_TYPE_UINT,   SLAB_SIZE,      "Slab size"                     )\
+    ACTION( slab_mem,               OPTION_TYPE_UINT,   SLAB_MEM,       "Max memory by slabs (byte)"    )\
+    ACTION( slab_prealloc,          OPTION_TYPE_BOOL,   SLAB_PREALLOC,  "Pre-allocate slabs at setup"   )\
+    ACTION( slab_evict_opt,         OPTION_TYPE_UINT,   SLAB_EVICT_OPT, "Eviction strategy"             )\
+    ACTION( slab_use_freeq,         OPTION_TYPE_BOOL,   SLAB_USE_FREEQ, "Use items in free queue?"      )\
+    ACTION( slab_profile,           OPTION_TYPE_STR,    SLAB_PROFILE,   "Specify entire slab profile"   )\
+    ACTION( slab_item_min,          OPTION_TYPE_UINT,   ITEM_SIZE_MIN,  "Minimum item size"             )\
+    ACTION( slab_item_max,          OPTION_TYPE_UINT,   ITEM_SIZE_MAX,  "Maximum item size"             )\
+    ACTION( slab_item_growth,       OPTION_TYPE_FPN,    ITEM_FACTOR,    "Slab class growth factor"      )\
+    ACTION( slab_item_max_ttl,      OPTION_TYPE_UINT,   ITEM_MAX_TTL,   "Max ttl in seconds"            )\
+    ACTION( slab_use_cas,           OPTION_TYPE_BOOL,   SLAB_USE_CAS,   "Store CAS value in item"       )\
+    ACTION( slab_hash_power,        OPTION_TYPE_UINT,   HASH_POWER,     "Power for lookup hash table"   )\
+    ACTION( slab_datapool,          OPTION_TYPE_STR,    SLAB_DATAPOOL,  "Path to data pool"             )\
+    ACTION( slab_datapool_prefault, OPTION_TYPE_BOOL,   SLAB_PREFAULT,  "Prefault data pool"            )
+
 
 typedef struct {
     SLAB_OPTION(OPTION_DECLARE)

--- a/test/datapool/check_datapool.c
+++ b/test/datapool/check_datapool.c
@@ -18,7 +18,7 @@
 START_TEST(test_datapool)
 {
     int fresh = 0;
-	struct datapool *pool = datapool_open(TEST_DATAFILE, TEST_DATASIZE, &fresh);
+    struct datapool *pool = datapool_open(TEST_DATAFILE, TEST_DATASIZE, &fresh, false);
     ck_assert_ptr_nonnull(pool);
     size_t s = datapool_size(pool);
     ck_assert_int_ge(s, TEST_DATASIZE);
@@ -26,7 +26,7 @@ START_TEST(test_datapool)
     ck_assert_ptr_nonnull(datapool_addr(pool));
     datapool_close(pool);
 
-    pool = datapool_open(TEST_DATAFILE, TEST_DATASIZE, &fresh);
+    pool = datapool_open(TEST_DATAFILE, TEST_DATASIZE, &fresh, false);
     ck_assert_ptr_nonnull(pool);
     ck_assert_int_eq(s, datapool_size(pool));
     ck_assert_int_eq(fresh, 0);
@@ -37,7 +37,7 @@ END_TEST
 START_TEST(test_devzero)
 {
     int fresh = 0;
-	struct datapool *pool = datapool_open(NULL, TEST_DATASIZE, &fresh);
+    struct datapool *pool = datapool_open(NULL, TEST_DATASIZE, &fresh, false);
     ck_assert_ptr_nonnull(pool);
     size_t s = datapool_size(pool);
     ck_assert_int_ge(s, TEST_DATASIZE);
@@ -45,7 +45,7 @@ START_TEST(test_devzero)
     ck_assert_ptr_nonnull(datapool_addr(pool));
     datapool_close(pool);
 
-    pool = datapool_open(NULL, TEST_DATASIZE, &fresh);
+    pool = datapool_open(NULL, TEST_DATASIZE, &fresh, false);
     ck_assert_ptr_nonnull(pool);
     ck_assert_int_eq(s, datapool_size(pool));
     ck_assert_int_eq(fresh, 1);


### PR DESCRIPTION
- Add prefault option used in PMEM to slab and cuckoo configuration
~~- Add possibility to pass custom storage engine configuration for benchmarks~~
~~- Fix logging options in benchmark~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/8)
<!-- Reviewable:end -->
