### PR TITLE
benchmark: extend existing slab and cuckoo benchmarks

### DIFF
--- a/benchmarks/bench_storage.c
+++ b/benchmarks/bench_storage.c
@@ -69,7 +69,7 @@ benchmark_create(struct benchmark *b, const char *config)
 {
     b->entries = NULL;
 
-    size_t nopts = OPTION_CARDINALITY(struct benchmark_specific);
+    unsigned nopts = OPTION_CARDINALITY(struct benchmark_specific);
 
     struct benchmark_specific opts = { BENCHMARK_OPTION(OPTION_INIT) };
     option_load_default((struct option *)&opts, nopts);
@@ -98,12 +98,10 @@ benchmark_create(struct benchmark *b, const char *config)
         return CC_EINVAL;
     }
 
-    if (O_BOOL(b, latency)) {
-        for (int op = 0; op < MAX_BENCHMARK_OPERATION; ++op) {
-            b->latency[op].samples =
-                cc_alloc(O(b, nops) * sizeof(struct duration));
-            b->latency[op].count = 0;
-        }
+    for (int op = 0; op < MAX_BENCHMARK_OPERATION; ++op) {
+        b->latency[op].samples = O_BOOL(b, latency) ?
+            cc_alloc(O(b, nops) * sizeof(struct duration)) : NULL;
+        b->latency[op].count = 0;
     }
 
     return CC_OK;
@@ -204,7 +202,7 @@ benchmark_run_operation(struct benchmark *b,
     size_t nsample = latency->count++;
 
     if (O_BOOL(b, latency))
-        duration_start(&latency->samples[nsample]);
+        duration_start_type(&latency->samples[nsample], DURATION_FAST);
 
     switch (op) {
         case BENCHMARK_GET:

--- a/benchmarks/bench_storage.h
+++ b/benchmarks/bench_storage.h
@@ -12,8 +12,11 @@ struct benchmark_entry {
     size_t value_size;
 };
 
-rstatus_i bench_storage_init(size_t item_size, size_t nentries);
+rstatus_i bench_storage_init(void *opts, size_t item_size, size_t nentries);
 rstatus_i bench_storage_deinit(void);
 rstatus_i bench_storage_put(struct benchmark_entry *e);
 rstatus_i bench_storage_get(struct benchmark_entry *e);
 rstatus_i bench_storage_rem(struct benchmark_entry *e);
+size_t bench_storage_config_nopts(void);
+void bench_storage_config_init(void *opts);
+

--- a/benchmarks/bench_storage.h
+++ b/benchmarks/bench_storage.h
@@ -17,6 +17,6 @@ rstatus_i bench_storage_deinit(void);
 rstatus_i bench_storage_put(struct benchmark_entry *e);
 rstatus_i bench_storage_get(struct benchmark_entry *e);
 rstatus_i bench_storage_rem(struct benchmark_entry *e);
-size_t bench_storage_config_nopts(void);
+unsigned bench_storage_config_nopts(void);
 void bench_storage_config_init(void *opts);
 

--- a/benchmarks/storage_cuckoo/storage_cuckoo.c
+++ b/benchmarks/storage_cuckoo/storage_cuckoo.c
@@ -4,17 +4,31 @@
 #include <storage/cuckoo/cuckoo.h>
 
 static cuckoo_metrics_st metrics = { CUCKOO_METRIC(METRIC_INIT) };
-static cuckoo_options_st options = { CUCKOO_OPTION(OPTION_INIT) };
+
+size_t
+bench_storage_config_nopts(void)
+{
+    return OPTION_CARDINALITY(cuckoo_options_st);
+}
+
+void
+bench_storage_config_init(void *options)
+{
+    cuckoo_options_st *opts = options;
+    *opts = (cuckoo_options_st){ CUCKOO_OPTION(OPTION_INIT) };
+
+    option_load_default(options, OPTION_CARDINALITY(cuckoo_options_st));
+}
 
 rstatus_i
-bench_storage_init(size_t item_size, size_t nentries)
+bench_storage_init(void *opts, size_t item_size, size_t nentries)
 {
-    option_load_default((struct option *)&options, OPTION_CARDINALITY(options));
-    options.cuckoo_policy.val.vuint = CUCKOO_POLICY_EXPIRE;
-    options.cuckoo_item_size.val.vuint = item_size + ITEM_OVERHEAD;
-    options.cuckoo_nitem.val.vuint = nentries;
+    cuckoo_options_st *options = opts;
+    options->cuckoo_policy.val.vuint = CUCKOO_POLICY_EXPIRE;
+    options->cuckoo_item_size.val.vuint = item_size + ITEM_OVERHEAD;
+    options->cuckoo_nitem.val.vuint = nentries;
 
-    cuckoo_setup(&options, &metrics);
+    cuckoo_setup(options, &metrics);
 
     return CC_OK;
 }

--- a/benchmarks/storage_cuckoo/storage_cuckoo.c
+++ b/benchmarks/storage_cuckoo/storage_cuckoo.c
@@ -5,7 +5,7 @@
 
 static cuckoo_metrics_st metrics = { CUCKOO_METRIC(METRIC_INIT) };
 
-size_t
+unsigned
 bench_storage_config_nopts(void)
 {
     return OPTION_CARDINALITY(cuckoo_options_st);

--- a/benchmarks/storage_slab/storage_slab.c
+++ b/benchmarks/storage_slab/storage_slab.c
@@ -5,7 +5,7 @@
 
 static slab_metrics_st metrics = { SLAB_METRIC(METRIC_INIT) };
 
-size_t
+unsigned
 bench_storage_config_nopts(void)
 {
     return OPTION_CARDINALITY(slab_options_st);

--- a/deps/ccommon/include/time/cc_timer.h
+++ b/deps/ccommon/include/time/cc_timer.h
@@ -49,6 +49,14 @@ struct duration;  /* data structure to measure duration */
  *   relationship between this unit and nanosecond can be obtained via another
  *   syscall
  */
+
+enum duration_type {
+    DURATION_PRECISE, /* default */
+    DURATION_FAST,
+
+    MAX_DURATION_TYPE
+};
+
 #ifdef OS_DARWIN
 struct duration {
     bool        started;
@@ -58,6 +66,7 @@ struct duration {
 };
 #elif defined OS_LINUX
 struct duration {
+    enum duration_type type;
     bool            started;
     bool            stopped;
     struct timespec start;
@@ -86,12 +95,12 @@ struct timeout {
     bool        is_intvl;
 };
 
-
 /* update duration */
 void duration_reset(struct duration *d);
 /* get a reading of duration and copy it without stopping the original timer */
 void duration_snapshot(struct duration *s, const struct duration *d);
 void duration_start(struct duration *d);
+void duration_start_type(struct duration *d, enum duration_type type);
 void duration_stop(struct duration *d);
 /* read duration */
 double duration_ns(struct duration *d);

--- a/deps/ccommon/include/time/cc_timer.h
+++ b/deps/ccommon/include/time/cc_timer.h
@@ -99,6 +99,18 @@ double duration_us(struct duration *d);
 double duration_ms(struct duration *d);
 double duration_sec(struct duration *d);
 
+static inline int
+duration_compare(const void *lhs, const void *rhs)
+{
+    double lns = duration_ns((struct duration *)lhs);
+    double rns = duration_ns((struct duration *)rhs);
+    if (lns < rns)
+        return -1;
+    if (lns > rns)
+        return 1;
+
+    return 0;
+}
 
 /*
  * Not all possible granularity can be meaningfully used for sleep or event.

--- a/deps/ccommon/src/time/cc_timer_darwin.c
+++ b/deps/ccommon/src/time/cc_timer_darwin.c
@@ -73,6 +73,12 @@ duration_start(struct duration *d)
 }
 
 void
+duration_start_type(struct duration *d, enum duration_type type)
+{
+    duration_start(d);
+}
+
+void
 duration_stop(struct duration *d)
 {
     ASSERT(d != NULL);

--- a/deps/ccommon/src/time/cc_timer_linux.c
+++ b/deps/ccommon/src/time/cc_timer_linux.c
@@ -25,24 +25,35 @@
  * CLOCK_REALTIME can be reset when clock has drifted, so it may not always be
  * monotonic, and should be avoided if possible.
  */
+static const clockid_t cid[MAX_DURATION_TYPE] = {
+    [DURATION_PRECISE] =
 #if defined(CLOCK_MONOTONIC_RAW)
-static const clockid_t cid = CLOCK_MONOTONIC_RAW;
+        CLOCK_MONOTONIC_RAW
 #elif defined(CLOCK_MONOTONIC)
-static const clockid_t cid = CLOCK_MONOTONIC;
+        CLOCK_MONOTONIC
 #elif defined(CLOCK_REALTIME)
-static const clockid_t cid = CLOCK_REALTIME;
+        CLOCK_REALTIME
 #else
-static const clockid_t cid = (clockid_t)-1;
+        (clockid_t)-1
 #endif
+,
+#if defined(CLOCK_MONOTONIC)
+        CLOCK_MONOTONIC
+#elif defined(CLOCK_REALTIME)
+        CLOCK_REALTIME
+#else
+        (clockid_t)-1
+#endif
+};
 
 static inline void
-_gettime(struct timespec *ts)
+_gettime(struct timespec *ts, enum duration_type type)
 {
     int ret;
 
-    ASSERT(cid != (clockid_t)-1);
+    ASSERT(cid[type] != (clockid_t)-1);
 
-    ret = clock_gettime(cid, ts);
+    ret = clock_gettime(cid[type], ts);
     if (ret == -1) {
         /*
          * Note(yao): for the purpose of this module, it doesn't make much sense
@@ -74,9 +85,16 @@ duration_reset(struct duration *d)
 void
 duration_start(struct duration *d)
 {
+    duration_start_type(d, DURATION_PRECISE);
+}
+
+void
+duration_start_type(struct duration *d, enum duration_type type)
+{
     ASSERT(d != NULL);
 
-    _gettime(&d->start);
+    _gettime(&d->start, type);
+    d->type = type;
     d->started = true;
 }
 
@@ -88,7 +106,7 @@ duration_snapshot(struct duration *s, const struct duration *d)
     s->started = true;
     s->start = d->start;
     s->stopped = true;
-    _gettime(&s->stop);
+    _gettime(&s->stop, s->type);
 }
 
 void
@@ -96,7 +114,7 @@ duration_stop(struct duration *d)
 {
     ASSERT(d != NULL);
 
-    _gettime(&d->stop);
+    _gettime(&d->stop, d->type);
     d->stopped = true;
 }
 
@@ -153,9 +171,8 @@ _now_ns(void)
 {
     struct timespec now;
 
-    _gettime(&now);
+    _gettime(&now, cid[DURATION_PRECISE]);
     return now.tv_sec * NSEC_PER_SEC + now.tv_nsec;
-
 }
 
 void


### PR DESCRIPTION
This patch:
 - adds automatic size adjustment for the slab micro benchmark
 - adds latency measurement
 - fixes composability of configs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/12)
<!-- Reviewable:end -->
