### PR TITLE
Fix duration_snapshot

### DIFF
--- a/deps/ccommon/src/time/cc_timer_linux.c
+++ b/deps/ccommon/src/time/cc_timer_linux.c
@@ -105,6 +105,7 @@ duration_snapshot(struct duration *s, const struct duration *d)
 
     s->started = true;
     s->start = d->start;
+    s->type = d->type;
     s->stopped = true;
     _gettime(&s->stop, s->type);
 }


### PR DESCRIPTION
- s->type contains garbage value which result hitting assert in _gettime

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/15)
<!-- Reviewable:end -->
