### PR TITLE
Fix recreate lruq

### DIFF
--- a/deps/ccommon/include/cc_queue.h
+++ b/deps/ccommon/include/cc_queue.h
@@ -694,7 +694,7 @@ struct {                                                                \
 
 #define TAILQ_REINIT(head, var, field, offset) do {                     \
     TAILQ_FIRST((head)) = var;                                          \
-    (head)->tqh_last = NULL;                                            \
+    *(head)->tqh_last = NULL;                                           \
     TAILQ_FOREACH(var, head, s_tqe) {                                   \
         if ((TAILQ_NEXT((var), field)) != NULL) {                       \
             TAILQ_NEXT((var), field) =                                  \


### PR DESCRIPTION
- dereference tqh last because it is pointer to pointer
- in recreate set p->next_item_in_slab to NULL if slab is full
- move heapinfo.curr to correct adress
- replace char* with uint8_t

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/16)
<!-- Reviewable:end -->
