### PR TITLE
Fix datapool prefault option 

### DIFF
--- a/src/datapool/datapool_pmem.c
+++ b/src/datapool/datapool_pmem.c
@@ -147,7 +147,7 @@ datapool_flag_clear(struct datapool *pool, int flag)
 
 /*
  * Opens, and if necessary initializes, a datapool that resides in the given
- * file. If no file is provided, the pool is allocated through cc_zalloc.
+ * file. If no file is provided, the pool is allocated through cc_alloc/cc_zalloc.
  *
  * The the datapool to retain its contents, the datapool_close() call must
  * finish successfully.
@@ -164,7 +164,7 @@ datapool_open(const char *path, size_t size, int *fresh, bool prefault)
     size_t map_size = size + sizeof(struct datapool_header);
 
     if (path == NULL) { /* fallback to DRAM if pmem is not configured */
-        pool->addr = cc_zalloc(map_size);
+        pool->addr = prefault ? cc_zalloc(map_size) : cc_alloc(map_size);
         pool->mapped_len = map_size;
         pool->is_pmem = 0;
         pool->file_backed = 0;

--- a/src/datapool/datapool_shm.c
+++ b/src/datapool/datapool_shm.c
@@ -20,7 +20,7 @@ datapool_open(const char *path, size_t size, int *fresh, bool prefault)
         *fresh = 1;
     }
 
-    return cc_zalloc(size);
+    return prefault ? cc_zalloc(size) : cc_alloc(size);
 }
 
 void

--- a/src/storage/cuckoo/cuckoo.h
+++ b/src/storage/cuckoo/cuckoo.h
@@ -18,7 +18,7 @@
 #define CUCKOO_POLICY CUCKOO_POLICY_RANDOM
 #define CUCKOO_MAX_TTL (30 * 24 * 60 * 60) /* 30 days */
 #define CUCKOO_DATAPOOL NULL
-#define CUCKOO_PREFAULT false
+#define CUCKOO_PREFAULT true
 
 /*          name                      type                default             description */
 #define CUCKOO_OPTION(ACTION)                                                                          \


### PR DESCRIPTION
- for shm call cc_alloc if prealloc is set to false
- this revert change introduced in 0759e52 replaced cc_alloc used for
heapinfo.base with cc_zalloc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/22)
<!-- Reviewable:end -->
