### PR TITLE
Remove unnecessary set variable to NULL

### DIFF
--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -368,7 +368,6 @@ _slab_heapinfo_teardown(void)
 
     datapool_set_user_data(pool_slab, &pool_metadata, sizeof(struct slab_pool_metadata));
     datapool_close(pool_slab);
-    pool_slab = NULL;
 }
 
 static rstatus_i


### PR DESCRIPTION
- datapool_close set variable to NULL using cc_free()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/28)
<!-- Reviewable:end -->
