### PR TITLE
Fix set user data and style issue

### DIFF
--- a/src/datapool/datapool_pmem.c
+++ b/src/datapool/datapool_pmem.c
@@ -277,13 +277,13 @@ datapool_size(struct datapool *pool)
 void
 datapool_set_user_data(const struct datapool *pool, const void *user_data, size_t user_size)
 {
-    ASSERT(user_size < DATAPOOL_USER_HEADER_LEN);
+    ASSERT(user_size < DATAPOOL_USER_HEADER_LEN - DATAPOOL_USER_LAYOUT_LEN);
     cc_memcpy(pool->hdr->user_data, user_data, user_size);
 }
 
 void
 datapool_get_user_data(const struct datapool *pool, void *user_data, size_t user_size)
 {
-    ASSERT(user_size < DATAPOOL_USER_HEADER_LEN);
+    ASSERT(user_size < DATAPOOL_USER_HEADER_LEN - DATAPOOL_USER_LAYOUT_LEN);
     cc_memcpy(user_data, pool->hdr->user_data, user_size);
 }

--- a/src/datapool/datapool_shm.c
+++ b/src/datapool/datapool_shm.c
@@ -8,7 +8,7 @@
 #include <cc_mm.h>
 
 struct datapool *
-datapool_open(const char *path, const char* user_signature, size_t size, int *fresh, bool prefault)
+datapool_open(const char *path, const char *user_signature, size_t size, int *fresh, bool prefault)
 {
     if (path != NULL) {
         log_warn("attempted to open a file-based data pool without"

--- a/test/datapool/check_datapool.c
+++ b/test/datapool/check_datapool.c
@@ -62,6 +62,29 @@ START_TEST(test_devzero)
 }
 END_TEST
 
+START_TEST(test_datapool_userdata)
+{
+#define MAX_USER_DATA_SIZE 2000
+    char data_set[MAX_USER_DATA_SIZE] = {0};
+    char data_get[MAX_USER_DATA_SIZE] = {0};
+
+    struct datapool *pool = datapool_open(TEST_DATAFILE, TEST_DATA_NAME, TEST_DATASIZE, NULL, false);
+    ck_assert_ptr_nonnull(pool);
+    cc_memset(data_set, 'A', MAX_USER_DATA_SIZE);
+    datapool_set_user_data(pool, data_set, MAX_USER_DATA_SIZE);
+    datapool_close(pool);
+
+    pool = datapool_open(TEST_DATAFILE, TEST_DATA_NAME, TEST_DATASIZE, NULL, false);
+    ck_assert_ptr_nonnull(pool);
+    datapool_get_user_data(pool, data_get, MAX_USER_DATA_SIZE);
+    ck_assert_mem_eq(data_set, data_get, MAX_USER_DATA_SIZE);
+    datapool_close(pool);
+    test_teardown(TEST_DATAFILE);
+#undef MAX_USER_DATA_SIZE
+}
+END_TEST
+
+
 START_TEST(test_datapool_prealloc)
 {
     struct datapool *pool = datapool_open(TEST_DATAFILE, TEST_DATA_NAME, TEST_DATASIZE, NULL, true);
@@ -147,6 +170,7 @@ datapool_suite(void)
     TCase *tc_pool = tcase_create("pool");
     tcase_add_test(tc_pool, test_datapool);
     tcase_add_test(tc_pool, test_devzero);
+    tcase_add_test(tc_pool, test_datapool_userdata);
     tcase_add_test(tc_pool, test_datapool_prealloc);
     tcase_add_test(tc_pool, test_datapool_max_length_signature);
     tcase_add_test(tc_pool, test_datapool_empty_signature);


### PR DESCRIPTION
ASSERT is now is 2048 bytes (whole datapool user header size) and should be 2000 bytes (datapoll user data size)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/31)
<!-- Reviewable:end -->
