### PR TITLE
Fix reinit of tailq on pmem

### DIFF
--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -217,11 +217,13 @@ _slab_lruq_rebuild(const uint8_t *heap_start)
 
     datapool_get_user_data(pool_slab, &heap_metadata, sizeof(struct slab_pool_metadata));
 
-    ptrdiff_t offset = heap_start - (uint8_t *)heap_metadata.usr_pool_addr;
+    if (heap_metadata.slab_lruq_head) {
+        ptrdiff_t offset = heap_start - (uint8_t *)heap_metadata.usr_pool_addr;
 
-    struct slab *slab = (void *)((uint8_t *)heap_metadata.slab_lruq_head + offset);
+        struct slab *slab = (void *)((uint8_t *)heap_metadata.slab_lruq_head + offset);
 
-    TAILQ_REINIT(&heapinfo.slab_lruq, slab, s_tqe, offset);
+        TAILQ_REINIT(&heapinfo.slab_lruq, slab, s_tqe, offset);
+    }
 }
 
 /*


### PR DESCRIPTION
Without this check when restart empty database it leads to segfault while there will be garbage in slab - check ensures that TAILQ_INSERT method was called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/33)
<!-- Reviewable:end -->
