### PR TITLE
Fix now_ns() method

### DIFF
--- a/deps/ccommon/src/time/cc_timer_linux.c
+++ b/deps/ccommon/src/time/cc_timer_linux.c
@@ -172,7 +172,7 @@ _now_ns(void)
 {
     struct timespec now;
 
-    _gettime(&now, cid[DURATION_PRECISE]);
+    _gettime(&now, DURATION_PRECISE);
     return now.tv_sec * NSEC_PER_SEC + now.tv_nsec;
 }
 


### PR DESCRIPTION
- _gettime takes duration_type as parameter not clockid_t ( fix 6329d28 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/34)
<!-- Reviewable:end -->
