### PR TITLE
Properly cleaning after partial request

### DIFF
--- a/src/server/slimcache/data/process.c
+++ b/src/server/slimcache/data/process.c
@@ -444,6 +444,7 @@ process_request(struct response *rsp, struct request *req)
 static inline void
 _cleanup(struct request **req, struct response **rsp)
 {
+    request_reset(*req);
     request_return(req);
     response_return_all(rsp);
 }


### PR DESCRIPTION
- revert solution from 6e45631
- move handling partial request later
- assign request to data to clean it up properly in case of failure
- add cleanup to reset **req->rstate** and avoid "default" case in parse_req for quit command in sequence:
\> set foo 0 0 3
\> bar
\> quit
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/38)
<!-- Reviewable:end -->
