### PR TITLE
Fix for static analysis issues

### DIFF
--- a/benchmarks/bench_storage.c
+++ b/benchmarks/bench_storage.c
@@ -76,6 +76,7 @@ benchmark_create(struct benchmark *b, const char *config)
     nopts += bench_storage_config_nopts();
 
     b->options = cc_alloc(sizeof(struct option) * nopts);
+    ASSERT(b->options != NULL);
     b->options->benchmark = opts;
 
     bench_storage_config_init(b->options->engine);
@@ -84,6 +85,8 @@ benchmark_create(struct benchmark *b, const char *config)
         FILE *fp = fopen(config, "r");
         if (fp == NULL) {
             log_crit("failed to open the config file");
+            cc_free(b->options);
+
             return CC_EINVAL;
         }
         option_load_file(fp, (struct option *)b->options, nopts);
@@ -93,6 +96,7 @@ benchmark_create(struct benchmark *b, const char *config)
     if (O(b, entry_min_size) <= sizeof(benchmark_key_u)) {
         log_crit("entry_min_size must larger than %lu",
             sizeof(benchmark_key_u));
+        cc_free(b->options);
 
         return CC_EINVAL;
     }
@@ -305,6 +309,10 @@ benchmark_run(struct benchmark *b)
     duration_stop(&d);
 
     bench_storage_deinit();
+
+    array_destroy(&in);
+    array_destroy(&in2);
+    array_destroy(&out);
 
     return d;
 }

--- a/src/datapool/datapool_pmem.c
+++ b/src/datapool/datapool_pmem.c
@@ -142,14 +142,14 @@ datapool_initialize(struct datapool *pool, const char *user_name)
 }
 
 static void
-datapool_flag_set(struct datapool *pool, int flag)
+datapool_flag_set(struct datapool *pool, uint64_t flag)
 {
     pool->hdr->flags |= flag;
     datapool_sync_hdr(pool);
 }
 
 static void
-datapool_flag_clear(struct datapool *pool, int flag)
+datapool_flag_clear(struct datapool *pool, uint64_t flag)
 {
     pool->hdr->flags &= ~flag;
     datapool_sync_hdr(pool);


### PR DESCRIPTION
Changes:
Preventing possible memory leak in function benchmark_run in bench_storage.c
Preventing from bitwise oprration on operands of different size
Adding an assertion for NULL
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/40)
<!-- Reviewable:end -->
