### PR TITLE
cc_declare_itt_function fix

### DIFF
--- a/deps/ccommon/include/cc_itt.h
+++ b/deps/ccommon/include/cc_itt.h
@@ -13,8 +13,8 @@ extern "C" {
 
 #define ITT_DOMAIN_NAME "cc_itt"
 
-#define cc_declare_itt_function(_name)                                           \
-    __itt_heap_function _name
+#define cc_declare_itt_function(_keyword, _name)                                 \
+    _keyword __itt_heap_function _name
 
 #define cc_create_itt_malloc(_name)                                              \
     _name = __itt_heap_function_create(#_name, ITT_DOMAIN_NAME)
@@ -52,7 +52,7 @@ extern "C" {
     __itt_heap_internal_access_end()
 
 #else
-#define cc_declare_itt_function(_name)
+#define cc_declare_itt_function(_keyword, _name)
 #define cc_create_itt_malloc(_name)
 #define cc_create_itt_free(_name)
 #define cc_create_itt_realloc(_name)

--- a/src/storage/cuckoo/cuckoo.c
+++ b/src/storage/cuckoo/cuckoo.c
@@ -63,8 +63,8 @@ static size_t hash_size; /* item_size * max_nitem, computed at setup */
     DECR_N(cuckoo_metrics, item_data_curr, item_datalen(it));               \
 } while(0)
 
-static cc_declare_itt_function(cuckoo_malloc);
-static cc_declare_itt_function(cuckoo_free);
+cc_declare_itt_function(static, cuckoo_malloc);
+cc_declare_itt_function(static, cuckoo_free);
 
 static inline uint32_t vlen(struct val *val)
 {

--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -61,8 +61,8 @@ delta_time_i max_ttl = ITEM_MAX_TTL;
 static bool slab_init = false;
 slab_metrics_st *slab_metrics = NULL;
 
-cc_declare_itt_function(slab_malloc);
-cc_declare_itt_function(slab_free);
+cc_declare_itt_function(,slab_malloc);
+cc_declare_itt_function(,slab_free);
 
 void
 slab_print(void)

--- a/src/storage/slab/slab.h
+++ b/src/storage/slab/slab.h
@@ -147,8 +147,8 @@ TAILQ_HEAD(slab_tqh, slab);
 extern struct hash_table *hash_table;
 extern size_t slab_size;
 extern slab_metrics_st *slab_metrics;
-extern cc_declare_itt_function(slab_malloc);
-extern cc_declare_itt_function(slab_free);
+cc_declare_itt_function(extern, slab_malloc);
+cc_declare_itt_function(extern, slab_free);
 
 /*
  * Return the usable space for item sized chunks that would be carved out


### PR DESCRIPTION
- fix compiler warning: useless storage class specifier in empty
declaration if HAVE_ITT_INSTRUMENTATION=OFF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/49)
<!-- Reviewable:end -->
