### PR TITLE
slab metrics unit test: test_metrics_evict_lru_basic

### DIFF
--- a/test/storage/slab_pmem/check_slab_pmem.c
+++ b/test/storage/slab_pmem/check_slab_pmem.c
@@ -1297,6 +1297,89 @@ START_TEST(test_metrics_lruq_rebuild)
 }
 END_TEST
 
+START_TEST(test_metrics_evict_lru_basic)
+{
+#define MY_SLAB_SIZE 160
+#define MY_SLAB_MAXBYTES 160
+    /**
+     * These are the slabs that will be created with these parameters:
+     *
+     * slab size 160, slab hdr size 36, item hdr size 40, item chunk size44, total memory 320
+     * class   1: items       2  size      48  data       8  slack      28
+     * class   2: items       1  size     120  data      80  slack       4
+     *
+     * If we use 8 bytes of key+value, it will use the class 1 that can fit
+     * two elements. The third one will cause a full slab eviction.
+     *
+     **/
+#define KEY_LENGTH 2
+#define VALUE_LENGTH 8
+#define NUM_ITEMS 2
+
+    size_t i;
+    struct bstring key[NUM_ITEMS + 1] = {
+        {KEY_LENGTH, "aa"},
+        {KEY_LENGTH, "bb"},
+        {KEY_LENGTH, "cc"},
+    };
+    struct bstring val[NUM_ITEMS + 1] = {
+        {VALUE_LENGTH, "aaaaaaaa"},
+        {VALUE_LENGTH, "bbbbbbbb"},
+        {VALUE_LENGTH, "cccccccc"},
+    };
+    item_rstatus_e status;
+    struct item *it;
+
+    option_load_default((struct option *)&options, OPTION_CARDINALITY(options));
+    options.slab_size.val.vuint = MY_SLAB_SIZE;
+    options.slab_mem.val.vuint = MY_SLAB_MAXBYTES;
+    options.slab_evict_opt.val.vuint = EVICT_CS;
+    options.slab_item_max.val.vuint = MY_SLAB_SIZE - SLAB_HDR_SIZE;
+    options.slab_datapool.val.vstr = DATAPOOL_PATH;
+
+    test_teardown(1);
+    slab_setup(&options, &metrics);
+
+    for (i = 0; i < NUM_ITEMS + 1; i++) {
+        time_update();
+        status = item_reserve(&it, &key[i], &val[i], val[i].len, 0, INT32_MAX);
+        ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
+        item_insert(it, &key[i]);
+        ck_assert_msg(item_get(&key[i]) != NULL, "item %lu not found", i);
+    }
+
+    ck_assert_msg(item_get(&key[0]) == NULL,
+        "item 0 found, expected to be evicted");
+    ck_assert_msg(item_get(&key[1]) == NULL,
+        "item 1 found, expected to be evicted");
+    ck_assert_msg(item_get(&key[2]) != NULL,
+        "item 2 not found");
+
+    slab_metrics_st copy = metrics;
+
+    metric_reset((struct metric *)&metrics, METRIC_CARDINALITY(metrics));
+
+    test_teardown(0);
+    slab_setup(&options, &metrics);
+
+    test_assert_metrics((struct metric *)&copy, (struct metric *)&metrics, METRIC_CARDINALITY(metrics));
+
+    ck_assert_msg(item_get(&key[0]) == NULL,
+        "item 0 found afer restart, expected to be evicted");
+    ck_assert_msg(item_get(&key[1]) == NULL,
+        "item 1 found after restart, expected to be evicted");
+    ck_assert_msg(item_get(&key[2]) != NULL,
+        "item 2 not found after restart");
+
+
+#undef KEY_LENGTH
+#undef VALUE_LENGTH
+#undef NUM_ITEMS
+#undef MY_SLAB_SIZE
+#undef MY_SLAB_MAXBYTES
+}
+END_TEST
+
 /*
  * test suite
  */
@@ -1339,6 +1422,7 @@ slab_suite(void)
     tcase_add_test(tc_smetrics, test_metrics_reserve_backfill_link);
     tcase_add_test(tc_smetrics, test_metrics_append_basic);
     tcase_add_test(tc_smetrics, test_metrics_lruq_rebuild);
+    tcase_add_test(tc_smetrics, test_metrics_evict_lru_basic);
 
     return s;
 }


### PR DESCRIPTION
Simple slab metrics unit test for pmem: test_metrics_evict_lru_basic
Failure - assertion message:
Saved:
>STATS slab_req 2
STATS slab_evict 1
STATS item_curr 3
STATS item_alloc 3
STATS item_linked_curr 3
STATS item_link 3
STATS item_keyval_byte 30
STATS item_val_byte 24

After restart:

>STATS slab_req 1
STATS slab_evict 0
STATS item_curr 1
STATS item_alloc 1
STATS item_linked_curr 1
STATS item_link 1
STATS item_keyval_byte 10
STATS item_val_byte 8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/55)
<!-- Reviewable:end -->
