### PR TITLE
slab metrics unit test: test_metrics_flush_basic

### DIFF
--- a/test/storage/slab_pmem/check_slab_pmem.c
+++ b/test/storage/slab_pmem/check_slab_pmem.c
@@ -1173,6 +1173,7 @@ START_TEST(test_metrics_append_basic)
 #define KEY "key"
 #define VAL "val"
 #define APPEND "append"
+
     struct bstring key, val, append;
     item_rstatus_e status;
     struct item *it;
@@ -1212,6 +1213,61 @@ START_TEST(test_metrics_append_basic)
 #undef KEY
 #undef VAL
 #undef APPEND
+}
+END_TEST
+
+START_TEST(test_metrics_flush_basic)
+{
+#define KEY1 "key1"
+#define VAL1 "val1"
+#define KEY2 "key2"
+#define VAL2 "val2"
+
+    struct bstring key1, val1, key2, val2;
+    item_rstatus_e status;
+    struct item *it;
+
+    test_reset(1);
+
+    key1 = str2bstr(KEY1);
+    val1 = str2bstr(VAL1);
+
+    key2 = str2bstr(KEY2);
+    val2 = str2bstr(VAL2);
+
+    time_update();
+    status = item_reserve(&it, &key1, &val1, val1.len, 0, INT32_MAX);
+    ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
+    item_insert(it, &key1);
+
+    time_update();
+    status = item_reserve(&it, &key2, &val2, val2.len, 0, INT32_MAX);
+    ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
+    item_insert(it, &key2);
+
+    item_flush();
+
+    it = item_get(&key1);
+    ck_assert_msg(it == NULL, "item with key %.*s still exists after flush", key1.len, key1.data);
+    it = item_get(&key2);
+    ck_assert_msg(it == NULL, "item with key %.*s still exists after flush", key2.len, key2.data);
+
+    slab_metrics_st copy = metrics;
+
+    metric_reset((struct metric *)&metrics, METRIC_CARDINALITY(metrics));
+    test_reset(0);
+
+    test_assert_metrics((struct metric *)&copy, (struct metric *)&metrics, METRIC_CARDINALITY(metrics));
+
+    it = item_get(&key1);
+    ck_assert_msg(it == NULL, "item with key %.*s still exists after flush", key1.len, key1.data);
+    it = item_get(&key2);
+    ck_assert_msg(it == NULL, "item with key %.*s still exists after flush", key2.len, key2.data);
+
+#undef KEY1
+#undef VAL1
+#undef KEY2
+#undef VAL2
 }
 END_TEST
 
@@ -1338,6 +1394,7 @@ slab_suite(void)
     tcase_add_test(tc_smetrics, test_metrics_insert_large);
     tcase_add_test(tc_smetrics, test_metrics_reserve_backfill_link);
     tcase_add_test(tc_smetrics, test_metrics_append_basic);
+    tcase_add_test(tc_smetrics, test_metrics_flush_basic);
     tcase_add_test(tc_smetrics, test_metrics_lruq_rebuild);
 
     return s;


### PR DESCRIPTION
Simple slab metrics unit test for pmem: test_metrics_flush_basic
Failure - assertion message:
Saved:
>STATS item_alloc 2
STATS item_dealloc 2
STATS item_link 2
STATS item_unlink 2

After restart:

>STATS item_alloc 0
STATS item_dealloc 0
STATS item_link 0
STATS item_unlink 0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/56)
<!-- Reviewable:end -->
