### PR TITLE
Corrects teardown when wrong pool was used

### DIFF
--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -362,14 +362,16 @@ _slab_heapinfo_setup(void)
 static void
 _slab_heapinfo_teardown(void)
 {
-    struct slab_pool_metadata pool_metadata =
-    {
-        datapool_addr(pool_slab),
-        TAILQ_FIRST(&heapinfo.slab_lruq)
-    };
+    if (pool_slab) {
+        struct slab_pool_metadata pool_metadata =
+        {
+            datapool_addr(pool_slab),
+            TAILQ_FIRST(&heapinfo.slab_lruq)
+        };
 
-    datapool_set_user_data(pool_slab, &pool_metadata, sizeof(struct slab_pool_metadata));
-    datapool_close(pool_slab);
+        datapool_set_user_data(pool_slab, &pool_metadata, sizeof(struct slab_pool_metadata));
+        datapool_close(pool_slab);
+    }
 }
 
 static rstatus_i

--- a/test/storage/slab_pmem/check_slab_pmem.c
+++ b/test/storage/slab_pmem/check_slab_pmem.c
@@ -9,6 +9,7 @@
 #include <check.h>
 #include <stdio.h>
 #include <string.h>
+#include <sysexits.h>
 
 /* define for each suite, local scope due to macro visibility rule */
 #define SUITE_NAME "slab"
@@ -1199,6 +1200,21 @@ START_TEST(test_metrics_lruq_rebuild)
 }
 END_TEST
 
+
+START_TEST(test_setup_wrong_path)
+{
+#define DATAPOOL_PATH_WRONG "./"
+
+    option_load_default((struct option *)&options, OPTION_CARDINALITY(options));
+    options.slab_datapool.val.vstr = DATAPOOL_PATH_WRONG;
+
+    slab_setup(&options, &metrics);
+
+#undef DATAPOOL_PATH_WRONG
+}
+END_TEST
+
+
 /*
  * test suite
  */
@@ -1231,6 +1247,7 @@ slab_suite(void)
     tcase_add_test(tc_slab, test_evict_lru_basic);
     tcase_add_test(tc_slab, test_refcount);
     tcase_add_test(tc_slab, test_evict_refcount);
+    tcase_add_exit_test(tc_slab, test_setup_wrong_path, EX_CONFIG);
 
     TCase *tc_smetrics = tcase_create("slab metrics");
     suite_add_tcase(s, tc_smetrics);


### PR DESCRIPTION
In situations when pm pool creation failed, teardown process causes
SIGSEGV due to accessing empty datapool structure. Fail may be caused
by wrong size, path or file permissions. This commit skips heapinfo teardown
in such situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/62)
<!-- Reviewable:end -->
