### PR TITLE
Rename tcp-nodelay to tcp_nodelay.

### DIFF
--- a/scripts/load_testing/client_config.py
+++ b/scripts/load_testing/client_config.py
@@ -25,7 +25,7 @@ def generate_config(rate, connections, vsize, slab_mem, threads):
   config_str = '''
 [general]
 clients = {threads}
-tcp-nodelay = true
+tcp_nodelay = true
 poolsize = {connections} # this specifies number of connection per thread
 # runtime ~= windows x duration
 windows = 2


### PR DESCRIPTION
The tcp-nodelay parameter in rpc-perf tool was renamed to tcp_nodelay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pelikan/65)
<!-- Reviewable:end -->
